### PR TITLE
Integration agl functionality into prod-devel

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 
-do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
-do_compile[depends] += "domd-image-weston:do_${BB_DEFAULT_TASK}"
+do_configure[depends] += "domd-agl-cluster-demo-platform:do_domd_install_machine_overrides"
+do_compile[depends] += "domd-agl-cluster-demo-platform:do_${BB_DEFAULT_TASK}"
 
 XT_GUESTS_BUILD ?= "doma"
 XT_GUESTS_INSTALL ?= "doma"

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -29,7 +29,7 @@ python __anonymous () {
 ################################################################################
 # Generic ARMv8
 ################################################################################
-SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/dom0.xml;scmdata=keep"
+SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_cockpit_demo/dom0.xml;scmdata=keep"
 
 ###############################################################################
 # extra layers and files to be put after Yocto's do_unpack into inner builder
@@ -71,7 +71,7 @@ python do_configure_append() {
 }
 
 do_install_append () {
-    local LAYERDIR=${TOPDIR}/../meta-xt-prod-devel
+    local LAYERDIR=${TOPDIR}/../meta-xt-prod-cockpit-demo
     local TARGET="generic-armv8-xt"
     find ${LAYERDIR}/doc -iname "uirfs.sh" -exec cp -f {} ${DEPLOY_DIR}/dom0-image-thin-initramfs/images/${TARGET} \; || true
 }

--- a/recipes-domd/domd-agl-cluster-demo-platform/domd-agl-cluster-demo-platform.bbappend
+++ b/recipes-domd/domd-agl-cluster-demo-platform/domd-agl-cluster-demo-platform.bbappend
@@ -1,5 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../domd-image-weston/files:"
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
 
 ###############################################################################
 # extra layers and files to be put after Yocto's do_unpack into inner builder
@@ -13,7 +14,7 @@ XT_QUIRK_UNPACK_SRC_URI += "\
 "
 
 SRC_URI_rcar_append = " \
-    repo://github.com/iusyk/manifests;protocol=https;branch=devel-agl;manifest=prod_devel_demo2020/domd.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_cockpit_demo_src/domd.xml;scmdata=keep \
 "
 
 XT_QUIRK_PATCH_SRC_URI_append_h3ulcb-4x2g-kf = "\
@@ -138,6 +139,7 @@ configure_versions_kingfisher() {
     # Do not enable surroundview which cannot be used
     base_add_conf_value ${local_conf} DISTRO_FEATURES_remove " surroundview"
     base_update_conf_value ${local_conf} PACKAGECONFIG_remove_pn-libcxx "unwind"
+    base_update_conf_value ${local_conf} DISTRO_FEATURES_append " pvcamera"
 
     # Remove the following if we use prebuilt EVA proprietary "graphics" packages
     if [ ! -z ${XT_RCAR_EVAPROPRIETARY_DIR} ];then
@@ -150,7 +152,7 @@ python do_configure_append_h3ulcb-4x2g-kf() {
 }
 
 do_install_append () {
-    local LAYERDIR=${TOPDIR}/../meta-xt-prod-devel-agl
+    local LAYERDIR=${TOPDIR}/../meta-xt-prod-cockpit-demo
     find ${LAYERDIR}/doc -iname "u-boot-env*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; || true
     if echo "${XT_GUESTS_INSTALL}" | grep -qi "domu";then
         find ${LAYERDIR}/doc -iname "mk_sdcard_image_domu.sh" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt/mk_sdcard_image.sh \; \

--- a/recipes-domd/domd-agl-cluster-demo-platform/domd-agl-cluster-demo-platform.bbappend
+++ b/recipes-domd/domd-agl-cluster-demo-platform/domd-agl-cluster-demo-platform.bbappend
@@ -1,0 +1,162 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/../domd-image-weston/files:"
+
+###############################################################################
+# extra layers and files to be put after Yocto's do_unpack into inner builder
+###############################################################################
+# these will be populated into the inner build system on do_unpack_xt_extras
+# N.B. xt_shared_env.inc MUST be listed AFTER meta-xt-prod-extra
+XT_QUIRK_UNPACK_SRC_URI += "\
+    file://meta-xt-prod-extra;subdir=repo \
+    file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
+    file://xen-version.inc;subdir=repo/meta-xt-prod-extra/recipes-extended/xen \
+"
+
+SRC_URI_rcar_append = " \
+    repo://github.com/iusyk/manifests;protocol=https;branch=devel-agl;manifest=prod_devel_demo2020/domd.xml;scmdata=keep \
+"
+
+XT_QUIRK_PATCH_SRC_URI_append_h3ulcb-4x2g-kf = "\
+    file://0001-linux-renesas-Remove-patch-230-from-renesas.scc.patch;patchdir=bsp/meta-rcar \
+"
+# these layers will be added to bblayers.conf on do_configure
+XT_QUIRK_BB_ADD_LAYER += "meta-xt-prod-extra"
+XT_QUIRK_BB_ADD_LAYER += "meta-xt-agl-base"
+# Override revision of AGL auxiliary layers
+# N.B. the revision to use must be aligned with Poky's version of AGL to be built with
+BRANCH = "thud"
+
+# Dom0 is a generic ARMv8 machine w/o machine overrides,
+# but still needs to know which system we are building,
+# e.g. Salvator-X M3 or H3, for instance
+# So, we provide machine overrides from this build the domain.
+# The same is true for Android build.
+addtask domd_install_machine_overrides after do_configure before do_compile
+python do_domd_install_machine_overrides() {
+    bb.debug(1, "Installing machine overrides")
+
+    d.setVar('XT_BB_CMDLINE', "-f domd-install-machine-overrides")
+    bb.build.exec_func("build_yocto_exec_bitbake", d)
+}
+
+#IMAGE_INSTALL_remove = "guest-addons-display-manager-service"
+
+################################################################################
+# Renesas R-Car
+################################################################################
+SRCREV_agl-repo = "icefish_9.0.2"
+SRCREV_img-proprietary = "ef1aa566d74a11c4d2ae9592474030a706b4cf39"
+
+GLES_VERSION_rcar = "1.11"
+
+configure_versions_rcar() {
+    local local_conf="${S}/build/conf/local.conf"
+
+    cd ${S}
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.14.0+git\%"
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_u-boot_rcar "v2018.09\%"
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_linux-renesas "4.14.75+git\%"
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_linux-libc-headers "4.14.75+git\%"
+    if [ -z ${XT_RCAR_EVAPROPRIETARY_DIR} ];then
+        base_update_conf_value ${local_conf} PREFERRED_PROVIDER_gles-user-module "gles-user-module"
+        base_update_conf_value ${local_conf} PREFERRED_VERSION_gles-user-module ${GLES_VERSION}
+
+        base_update_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-gles "kernel-module-gles"
+        base_update_conf_value ${local_conf} PREFERRED_VERSION_kernel-module-gles ${GLES_VERSION}
+
+        base_update_conf_value ${local_conf} PREFERRED_VERSION_gles-module-egl-headers ${GLES_VERSION}
+        base_add_conf_value ${local_conf} EXTRA_IMAGEDEPENDS "prepare-graphic-package"
+        base_add_conf_value ${local_conf} BBMASK "meta-agl/meta-agl-profile-graphical/recipes-multimedia/gstreamer1.0-plugins-bad/"
+    else
+        base_update_conf_value ${local_conf} PREFERRED_PROVIDER_virtual/libgles2 "rcar-proprietary-graphic"
+        base_update_conf_value ${local_conf} PREFERRED_PROVIDER_virtual/egl "rcar-proprietary-graphic"
+        base_set_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-pvrsrvkm "rcar-proprietary-graphic"
+        base_set_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-dc-linuxfb "rcar-proprietary-graphic"
+        base_set_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-gles "rcar-proprietary-graphic"
+        base_set_conf_value ${local_conf} PREFERRED_PROVIDER_gles-user-module "rcar-proprietary-graphic"
+        base_set_conf_value ${local_conf} PREFERRED_PROVIDER_gles-module-egl-headers "rcar-proprietary-graphic"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-images-vgpu/recipes-graphics/gles-module/"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-extra/recipes-graphics/gles-module/"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-graphics/gles-module/"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-graphics/wayland/"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-kernel/kernel-module-gles/"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/"
+        base_add_conf_value ${local_conf} BBMASK "meta-renesas/meta-rcar-gen3/recipes-kernel/kernel-module-gles/"
+        base_add_conf_value ${local_conf} BBMASK "meta-renesas/meta-rcar-gen3/recipes-graphics/gles-module/"
+        base_add_conf_value ${local_conf} BBMASK "meta-agl/meta-agl-profile-graphical/recipes-multimedia/gstreamer1.0-plugins-bad/"
+        xt_unpack_proprietary
+    fi
+
+    # Disable shared link for GO packages
+    base_set_conf_value ${local_conf} GO_LINKSHARED ""
+
+    # FIXME: normally bitbake fails with error if there are bbappends w/o recipes
+    # which is the case for agl-demo-platform's recipe-platform while building
+    # agl-image-weston: due to AGL's Yocto configuration recipe-platform is only
+    # added to bblayers if building agl-demo-platform, thus making bitbake to
+    # fail if this recipe is absent. Workaround this by allowing bbappends without
+    # corresponding recipies.
+    base_update_conf_value ${local_conf} BB_DANGLINGAPPENDS_WARNONLY "yes"
+    
+    # override console specified by default by the meta-rcar-gen3
+    # to be hypervisor's one
+    base_update_conf_value ${local_conf} SERIAL_CONSOLE "115200 hvc0"
+
+    # set default timezone to Las Vegas
+    base_update_conf_value ${local_conf} DEFAULT_TIMEZONE "US/Pacific"
+
+    base_update_conf_value ${local_conf} XT_GUESTS_INSTALL "${XT_GUESTS_INSTALL}"
+
+    if [ ! -z "${AOS_VIS_PLUGINS}" ];then
+        base_update_conf_value ${local_conf} AOS_VIS_PLUGINS "${AOS_VIS_PLUGINS}"
+    fi
+
+    # Network manager to use (possible values: systemd, connman).
+    # Pay attention that connman produces network issues, sometimes random,
+    # so it can't be used on XT products.
+    base_update_conf_value ${local_conf} VIRTUAL-RUNTIME_net_manager "systemd"
+
+    base_add_conf_value ${local_conf} ASSUME_PROVIDED "sync-native"
+    base_add_conf_value ${local_conf} HOSTTOOLS "sync"
+    base_add_conf_value ${local_conf} ASSUME_PROVIDED "bison-native"
+    base_add_conf_value ${local_conf} HOSTTOOLS  "bison"
+}
+
+python do_configure_append_rcar() {
+    bb.build.exec_func("configure_versions_rcar", d)
+}
+
+configure_versions_kingfisher() {
+    local local_conf="${S}/build/conf/local.conf"
+
+    cd ${S}
+    #FIXME: patch ADAS: do not use network setup as we provide our own
+    base_add_conf_value ${local_conf} BBMASK "meta-rcar-gen3-adas/recipes-core/systemd"
+    # Remove development tools from the image
+    base_add_conf_value ${local_conf} IMAGE_INSTALL_remove " strace eglibc-utils ldd rsync gdbserver dropbear opkg git subversion nano cmake vim"
+    base_add_conf_value ${local_conf} DISTRO_FEATURES_remove " opencv-sdk"
+    # Do not enable surroundview which cannot be used
+    base_add_conf_value ${local_conf} DISTRO_FEATURES_remove " surroundview"
+    base_update_conf_value ${local_conf} PACKAGECONFIG_remove_pn-libcxx "unwind"
+
+    # Remove the following if we use prebuilt EVA proprietary "graphics" packages
+    if [ ! -z ${XT_RCAR_EVAPROPRIETARY_DIR} ];then
+        base_update_conf_value ${local_conf} PACKAGECONFIG_remove_pn-cairo " egl glesv2"
+    fi
+}
+
+python do_configure_append_h3ulcb-4x2g-kf() {
+    bb.build.exec_func("configure_versions_kingfisher", d)
+}
+
+do_install_append () {
+    local LAYERDIR=${TOPDIR}/../meta-xt-prod-devel-agl
+    find ${LAYERDIR}/doc -iname "u-boot-env*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; || true
+    if echo "${XT_GUESTS_INSTALL}" | grep -qi "domu";then
+        find ${LAYERDIR}/doc -iname "mk_sdcard_image_domu.sh" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt/mk_sdcard_image.sh \; \
+        -exec cp -f {} ${DEPLOY_DIR}/mk_sdcard_image.sh \; || true
+    else
+        find ${LAYERDIR}/doc -iname "mk_sdcard_image.sh" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; \
+        -exec cp -f {} ${DEPLOY_DIR} \; || true
+    fi
+}

--- a/recipes-domd/domd-agl-cluster-demo-platform/files/remove_230-drivers-flag-buses-which-demand-DMA-configuration.patch
+++ b/recipes-domd/domd-agl-cluster-demo-platform/files/remove_230-drivers-flag-buses-which-demand-DMA-configuration.patch
@@ -1,0 +1,9 @@
+diff --git a/meta-rcar-gen3-adas/recipes-kernel/linux/linux-renesas/renesas-not-applied.scc b/meta-rcar-gen3-adas/recipes-kernel/linux/linux-renesas/renesas-not-applied.scc
+index 6d54284..6cf93d6 100644
+--- a/meta-rcar-gen3-adas/recipes-kernel/linux/linux-renesas/renesas-not-applied.scc
++++ b/meta-rcar-gen3-adas/recipes-kernel/linux/linux-renesas/renesas-not-applied.scc
+@@ -14,3 +14,4 @@
+ 0106-media-rcar-imr-Add-RSE-support.patch
+ 0110-mmc-tmio-Add-SDHI-SEQUENCER-support.patch
+ 0111-mmc-renesas_sdhi-Add-SDHI-SEQUENCER-support.patch
++0230-drivers-flag-buses-which-demand-DMA-configuration.patch

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -11,7 +11,7 @@ python __anonymous () {
 }
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=${XT_MANIFEST_FOLDER}/domd.xml;scmdata=keep \
+    repo://github.com/iusyk/manifests;protocol=https;branch=devel-agl;manifest=prod_devel_demo2020/domd.xml;scmdata=keep \
 "
 
 XT_QUIRK_UNPACK_SRC_URI += " \

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -6,12 +6,12 @@ python __anonymous () {
     product_name = d.getVar('XT_PRODUCT_NAME', True)
     folder_name = product_name.replace("-", "_")
     d.setVar('XT_MANIFEST_FOLDER', folder_name)
-    if product_name == "prod-devel-src" and not "domu" in d.getVar('XT_GUESTS_BUILD', True).split():
+    if product_name == "prod-cockpit-demo-src" and not "domu" in d.getVar('XT_GUESTS_BUILD', True).split():
         d.appendVar("XT_QUIRK_BB_ADD_LAYER", "meta-aos")
 }
 
 SRC_URI = " \
-    repo://github.com/iusyk/manifests;protocol=https;branch=devel-agl;manifest=prod_devel_demo2020/domd.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_cockpit_demo_src/domd.xml;scmdata=keep \
 "
 
 XT_QUIRK_UNPACK_SRC_URI += " \
@@ -198,7 +198,7 @@ python do_configure_append_rcar() {
 }
 
 do_install_append () {
-    local LAYERDIR=${TOPDIR}/../meta-xt-prod-devel
+    local LAYERDIR=${TOPDIR}/../meta-xt-prod-cockpit
     find ${LAYERDIR}/doc -iname "u-boot-env*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; || true
     find ${LAYERDIR}/doc -iname "mk_sdcard_image.sh" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; \
     -exec cp -f {} ${DEPLOY_DIR} \; || true

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-demo-hmi/cluster-dashboard-vis/cluster-dashboard-vis_git.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-demo-hmi/cluster-dashboard-vis/cluster-dashboard-vis_git.bb
@@ -1,0 +1,31 @@
+SRC_URI = "gitsm://github.com/xen-troops/agl-cluster-demo-vis.git;protocol=https"
+SRCREV  = "36622ac7a815f5c8feabf5f405b25ddcf398cda5"
+
+LICENSE     = "Apache-2.0 & BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ae6497158920d9524cf208c09cc4c984"
+
+PV = "1.0+git${SRCPV}"
+S  = "${WORKDIR}/git"
+
+# build-time dependencies
+DEPENDS += "qtquickcontrols2 qtwebsockets qlibwindowmanager"
+
+inherit pkgconfig cmake_qt5 aglwgt
+
+RDEPENDS_${PN} += " \
+	qlibwindowmanager \
+	qtquickcontrols \
+	qtquickcontrols-qmlplugins \
+	qtquickcontrols2 \
+	qtquickcontrols2-qmlplugins \
+	qtwebsockets \
+	qtwebsockets-qmlplugins \
+"
+
+VISSERVER = "10.0.0.1    wwwivi"
+
+pkg_postinst_ontarget_${PN} () {
+    if ! grep -q '${VISSERVER}' $D${sysconfdir}/hosts ; then
+        echo '${VISSERVER}' >> $D${sysconfdir}/hosts
+    fi
+}

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/sndbe.service
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/sndbe.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sound backend
+Requires=proc-xen.mount pulseaudio.service
+After=proc-xen.mount pulseaudio.service
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sleep 1
+ExecStart=/usr/bin/snd_be
+ExecStartPost=/usr/bin/xenstore-write drivers/sndbe/status ready
+ExecStop=/usr/bin/xenstore-write drivers/sndbe/status dead
+ExecStopPost=/usr/bin/xenstore-write drivers/sndbe/status dead
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/gles-user-module_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/gles-user-module_%.bbappend
@@ -1,0 +1,6 @@
+EXTRA_OEMAKE += "BIN_DESTDIR=${localstatedir}/local/bin"
+EXTRA_OEMAKE += "SHARE_DESTDIR=${localstatedir}/local/share"
+
+FILES_${PN}_append = "${localstatedir}/local/share/* \
+                      ${localstatedir}/local/bin/* \
+"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -38,6 +38,13 @@ IMAGE_INSTALL_remove = " \
 IMAGE_INSTALL_remove = " \
     packagegroup-graphics-renesas-proprietary \
 "
+IMAGE_INSTALL_append_kingfisher = " \
+    iw \
+"
+
+IMAGE_INSTALL_remove_kingfisher = " \
+    wireless-tools \
+"
 
 CORE_IMAGE_BASE_INSTALL_remove += "gtk+3-demo clutter-1.0-examples"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-platform/images/agl-cluster-demo-platform.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-platform/images/agl-cluster-demo-platform.bbappend
@@ -1,0 +1,2 @@
+
+IMAGE_INSTALL_remove="guest-addons-display-manager-service"

--- a/recipes-domu/domu-image-android/domu-image-android.bbappend
+++ b/recipes-domu/domu-image-android/domu-image-android.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 
 # we need MACHINEOVERRIDES from DomD build
-do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
+do_configure[depends] += "domd-agl-cluster-demo-platform:do_domd_install_machine_overrides"
 
 SRC_URI = " \
     repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu_android_host_tools.xml;scmdata=keep \

--- a/recipes-domu/domu-image-android/domu-image-android.bbappend
+++ b/recipes-domu/domu-image-android/domu-image-android.bbappend
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 do_configure[depends] += "domd-agl-cluster-demo-platform:do_domd_install_machine_overrides"
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu_android_host_tools.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_cockpit_demo/domu_android_host_tools.xml;scmdata=keep \
 "
 
 XT_BB_LAYERS_FILE = "meta-xt-prod-extra/doc/bblayers.conf.domu-image-android"


### PR DESCRIPTION
The cockpit-demo is based at meta-xt-prod-devel (branch:master, revision: 7f61664d297b0b02f3c88e5b40e826607e9652cb)
The following changes are done
-new append domd-agl-cluster-demo-platform.bbappend is added
-dom0 and domu(android),the dependency on domd-image-weston is replaced at domd-agl-cluster-demo-platform
-cluster-dashboard-vis recipe is added
