### PR TITLE
gles-user-module: Remove incorrect append

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/gles-user-module_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/gles-user-module_%.bbappend
@@ -1,6 +1,0 @@
-EXTRA_OEMAKE += "BIN_DESTDIR=${localstatedir}/local/bin"
-EXTRA_OEMAKE += "SHARE_DESTDIR=${localstatedir}/local/share"
-
-FILES_${PN}_append = "${localstatedir}/local/share/* \
-                      ${localstatedir}/local/bin/* \
-"


### PR DESCRIPTION
This commit removes append that erroneously appends
second instances of `BIN_DESTDIR` and `SHARE_DESTDIR`
with incorrect values during the build of proprietary sources.

Incorrect paths overrode already appended correct paths.
This resulted in the generation of an incorrect package with
prebuilt graphics - some executables placed into `var/local/bin`
instead of `usr/bin` as expected.
That incorrect package resulted in an error during the build
of the product with prebuilt graphics.

Fixes f268464cea2fe6f38f41241550b12158f1509ec3