### PR TITLE
optee-os: Switch to branch 3.9-xt-linux

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/conf/layer.conf
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-xt-prod-extra"
 BBFILE_PATTERN_meta-xt-prod-extra := "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-xt-prod-extra = "6"
+BBFILE_PRIORITY_meta-xt-prod-extra = "8"
 
 LAYERSERIES_COMPAT_meta-xt-prod-extra = "thud"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/xen-troops/optee_os.git;branch=3.9-xt-linux;protocol=https"


### PR DESCRIPTION
This PR overrides SRC_URI in optee_os.bb using an assignment with higher priority.