### PR TITLE
optee: enable 'AVB early TA' and RPMB

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -1,1 +1,8 @@
 SRC_URI = "git://github.com/xen-troops/optee_os.git;branch=3.9-xt-linux;protocol=https"
+
+EXTRA_OEMAKE_append = " \
+    CFG_RPMB_FS=y \
+    CFG_RPMB_WRITE_KEY=y \
+    CFG_EARLY_TA=y \
+    CFG_IN_TREE_EARLY_TAS=avb/023f8f1a-292a-432b-8fc4-de8471358067 \
+    "


### PR DESCRIPTION
These features are required for Adndroid.

Changes are taken without modifications from two commits from
meta-xt-prod-devel:
0d6175b97fc1554cc0d057552e86138161575d2e optee: enable AVB early TA
f04ed2d08746db01be4a9f00ee213404d3761f3c optee: enable RPMB support

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>