### PR TITLE
Update INSTALL.txt

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -13,7 +13,7 @@ Prerequisites:
 
 About:
 ======
-Prod-devel product is based on Renesas BSP, Xen hypervisor and Android. It contains a set of features required to have
+Cockpit-demo product is based on Renesas BSP, Xen hypervisor and Android. It contains a set of features required to have
 both Display and GPU support in several domains at the same time (device passthrough, PV Display, PV Sound, VGPU, etc).
 
 There are three domains which are running on top of Xen:
@@ -23,13 +23,14 @@ for managing VMs only (create/destroy/reboot guest domains). There is no HW assi
 As this domain is not 1:1 mapped, Xen controls IPMMU to do a proper address translations (IPA to PA) for DMA masters.
 It also contains different para-virtualized (PV) backends running inside it in order to provide guest domains
 (without HW assigned) with different services such as Audio, Display, Net, Block, etc.
-3. Either Android based domain named "DomA" or Linux based domain named "DomU".
-Both have different PV frontends running and don't have any HW assigned except GPU.
-The latter is shared between "DomD" and "DomA" ("DomU") in current setup.
+3. Android based domain named "DomA".
+It has different PV frontends running and don't have any HW assigned except GPU.
+The latter is shared between "DomD" and "DomA" in current setup.
 
 Build:
 ======
 Our build system uses set of additional meta layers and tools.
+
 1. Please, clone the following build scripts, master branch:
 
 git clone https://github.com/xen-troops/build-scripts.git
@@ -38,7 +39,7 @@ cd build-scripts
 2. In the build-scripts directory you will find a sample configuration
 file gcp-build-server-devel.cfg:
 
-cp gcp-build-server-devel.cfg xt-prod-devel.cfg
+cp gcp-build-server-devel.cfg xt-cockpit-demo.cfg
 
 3. Edit it to fit your environment.
 
@@ -48,56 +49,38 @@ xt_manifest_uri = https://github.com/xen-troops/meta-xt-products.git
 
 3.2 Please, change the variables under [path] section:
 
- - workspace_base_dir: change it to point to the place where the build will happen
- - workspace_storage_base_dir: change it to where downloads and other files will be put
+ - workspace_base_dir: specify folder where the build will happen
+ - workspace_storage_base_dir: specify folder for yocto's downloads
  - workspace_cache_base_dir: it points to state cache
 
 For example,
 
-workspace_base_dir = /home/workspace_base
-workspace_storage_base_dir = /home/workspace_storage_base
-workspace_cache_base_dir = /home/workspace_cache
+workspace_base_dir = /<your_path>/workspace_base
+workspace_storage_base_dir = /<your_path>/workspace_storage_base
+workspace_cache_base_dir = /<your_path>/workspace_cache
 
 3.3 Please, change the variables under [local_conf] section:
 
-3.3.1 The XT_GUESTS_INSTALL and XT_GUESTS_BUILD variables select the guest domain
-to be built and installed.
-
-For example (system with DomU),
-
-XT_GUESTS_INSTALL = "domu"
-XT_GUESTS_BUILD = "domu"
-
-For example (system with DomA),
+3.3.1 The XT_GUESTS_INSTALL and XT_GUESTS_BUILD variables can have just one value for this demo: 'doma'.
 
 XT_GUESTS_INSTALL = "doma"
 XT_GUESTS_BUILD = "doma"
 
-3.3.2 The XT_RCAR_EVAPROPRIETARY_DIR (DomD and DomU), XT_ANDROID_PREBUILDS_DIR (DomA) variables
-point to the place where prebuilt EVA proprietary "graphics" packages (hereafter "graphics" packages) will be copied in step #4.
+3.3.2 The XT_RCAR_EVAPROPRIETARY_DIR (DomD), XT_ANDROID_PREBUILDS_DIR (DomA) variables
+point to the place where prebuilt proprietary "graphics" packages (hereafter "graphics" packages) will be copied in step #4.
 
 If you are going to build Graphics DDK from sources (and don't use "graphics" packages), please remove that variables.
 In that case step #4 can be omitted.
 
-3.3.3 The XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR (DomD) variable points to the place where proprietary "multimedia" packages
-(hereafter "multimedia" packages) will be copied in step #5.
-
-If you are not going to use multimedia in DomD, please remove that variable. In that case step #5 can be omitted.
-
-3.3.4 Please note, the variables below are only applicable for system with DomA:
-AOS_VIS_PACKAGE_DIR should point to the directory with aos-vis package and symbolic link to
-corresponding *.ipk package.
-AOS_VIS_PLUGINS defines which VIS plugin to use as VIS data provider. This value can be set to
-"telemetryemulator", "renesassimulator".
-The "telemetryemulator" plugin uses prerecorded data which provided by telemetryemulator service launched in DomD.
-The "renesassimulator" plugin uses data provided by Renesas R-Car simulator.
-If the variable is not set, the "telemetryemulator" plugin will be built.
+3.3.3 AOS_VIS_PLUGINS defines which VIS plugin to use as VIS data provider.
+It should be set to "renesassimulatoradapter" for this demo project.
+The "renesassimulatoradapter" plugin uses data provided by Renesas R-Car simulator.
 
 4. Download and copy "graphics" packages to your local filesystem at some directory:
 
 4.1 DomA prebuilts:
 
- - rcar-prebuilts-salvator-xs-h3-xt-doma.tar.gz
+ - rcar-prebuilts-salvator-xs-h3-4x2g-xt-doma.tar.gz
 
 Unpack it to some "..PREBUILTS_FOLDER_PATH.."
 I.e. you should have such directories structure:
@@ -159,73 +142,30 @@ I.e. you should have such directories structure:
 
 XT_ANDROID_PREBUILDS_DIR should point to "..ANDROID_PREBUILTS_FOLDER_PATH.." folder.
 
-4.2 DomD and DomU (if latter is used instead of DomA) prebuilts:
+4.2 DomD prebuilts:
 
-For example (Salvator-X board with H3 ES3.0 SoC installed, 8GB RAM),
+For example (Salvator-XS board with H3 ES3.0 SoC installed, 8GB RAM):
 
- - rcar-proprietary-graphic-salvator-x-h3-4x2g-xt-domd.tar.gz
- - rcar-proprietary-graphic-salvator-x-h3-4x2g-xt-domu.tar.gz
+ - rcar-proprietary-graphic-salvator-xs-h3-4x2g-xt-domd.tar.gz
 
 Copy it to "..PROPRIETARY_FOLDER_PATH.." folder.
 
 XT_RCAR_EVAPROPRIETARY_DIR should point to "..PROPRIETARY_FOLDER_PATH.." folder.
 
-Due to the fact that the SoC is not actually changed for Salvator-XS 8GB and H3ULCB(-KF) 8GB boards (H3 ES3.0),
-you could reuse already provided binaries by making symlinks to corresponding archives.
+5. Run the build script for current stable release:
 
-For example (Salvator-XS),
-
-ln -s rcar-proprietary-graphic-salvator-x-h3-4x2g-xt-domd.tar.gz \
-rcar-proprietary-graphic-salvator-xs-h3-4x2g-xt-domd.tar.gz
-ln -s rcar-proprietary-graphic-salvator-x-h3-4x2g-xt-domu.tar.gz \
-rcar-proprietary-graphic-salvator-xs-h3-4x2g-xt-domu.tar.gz
-
-For example (H3ULCB),
-
-ln -s rcar-proprietary-graphic-salvator-x-h3-4x2g-xt-domd.tar.gz \
-rcar-proprietary-graphic-h3ulcb-4x2g-xt-domd.tar.gz
-ln -s rcar-proprietary-graphic-salvator-x-h3-4x2g-xt-domu.tar.gz \
-rcar-proprietary-graphic-h3ulcb-4x2g-xt-domu.tar.gz
-
-5. Only for the multimedia usage.
-Follow the procedure described in "Preliminary steps #1" from https://elinux.org/R-Car/Boards/Yocto-Gen3
-to download Multimedia and Graphics library and related Linux drivers. These software packages
-should be stored at the directory pointed by XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR variable.
-
-Please note, although only "multimedia" packages will be used here, there is no need
-to re-pack package archives in order to remove "graphics" packages, unneeded packages
-will be just skipped.
-
-6. Run the build script for current stable release:
-
-python ./build_prod.py --build-type dailybuild --machine MACHINE_NAME --product PRODUCT_NAME \
---branch RELEASE_NAME --with-local-conf --config xt-prod-devel.cfg --with-do-build
-
-Where the PRODUCT_NAME depends on whether "graphics" packages are used or not:
-- devel (to use "graphics" packages)
-- devel-src (to build Graphics DDK from sources)
-
-Where the RELEASE_NAME name is the name of the release to be built.
-This is done in order to track product releases easily and have a possibility to build any release
-just by pointing a proper release name.
-Please note, if "branch" parameter is not set then the current product's snapshot will be built.
+python3 ./build_prod.py --machine MACHINE_NAME --product PRODUCT_NAME \
+--with-local-conf --config xt-cockpit-demo.cfg --with-do-build
 
 Hereafter the supported MACHINE_NAMEs are:
-- salvator-x-h3  (Salvator-X board with H3 ES2.0 SoC installed, 4GB RAM)
-- salvator-x-h3-4x2g (Salvator-X board with H3 ES3.0 SoC installed, 8GB RAM)
-- salvator-x-m3  (Salvator-X board with M3 SoC installed, 4GB RAM)
-- salvator-xs-h3  (Salvator-XS board with H3 ES2.0 SoC installed, 4GB RAM)
 - salvator-xs-h3-4x2g (Salvator-XS board with H3 ES3.0 SoC installed, 8GB RAM)
-- salvator-xs-m3n (Salvator-XS board with M3N SoC installed, 2GB RAM)
-- h3ulcb (H3ULCB board with H3 ES2.0 SoC installed, 4GB RAM)
-- m3ulcb (M3ULCB board with M3 SoC installed, 2GB RAM)
-- h3ulcb-4x2g (H3ULCB board with H3 ES3.0 SoC installed, 8GB RAM)
 - h3ulcb-4x2g-kf (H3ULCB KF board with H3 ES3.0 SoC installed, 8GB RAM)
 
-Please note, you are not able to build and run DomA for the m3ulcb and salvator-xs-m3n
-machines due to limited memory resources (only 2GB RAM). The system with DomU is only an option for them.
+Where the PRODUCT_NAME depends on whether "graphics" packages are used or not:
+- cockpit-demo (to use "graphics" packages)
+- cockpit-demo-src (to build Graphics DDK from sources)
 
-7. You are done. The artifacts of the build are located at workspace_base directory:
+6. You are done. The artifacts of the build are located at workspace_base directory:
 
 workspace_base/build/build/deploy/
 ├── dom0-image-thin-initramfs
@@ -246,14 +186,7 @@ workspace_base/build/build/deploy/
 │           ├── vendor.img
 │           └── vmlinux
 │
-│  - or -
-│
-├── domu-image-weston
-│   └── images
-│       └── MACHINE_NAME-xt
-│
 └── mk_sdcard_image.sh
-
 
 Images are located at:
 
@@ -281,11 +214,6 @@ Here we get a rootfs image for DomU:
   - vendor.img - android vendor image
   - userdata.img - android vendor image
 
-- DomU:
-workspace_base/build/build/deploy/domu-image-weston/images/MACHINE-NAME-xt
-Here we get a rootfs image for DomU:
-  - core-image-weston-MACHINE_NAME-xt.tar.bz2 - rootfs image for DomU
-
 Build logs are located at:
 - Domain-0:
 workspace_base/build/build/log/dom0-image-thin-initramfs/cooker/generic-armv8-xt
@@ -293,42 +221,13 @@ workspace_base/build/build/log/dom0-image-thin-initramfs/cooker/generic-armv8-xt
 workspace_base/build/build/log/domd-image-weston/cooker/MACHINE-NAME-xt
 - DomA:
 workspace_base/build/build/log/domu-image-android/cooker/qemux86-64
-- DomU:
-workspace_base/build/build/log/domu-image-weston/cooker/MACHINE-NAME-xt
-
-8. If one wants to build any domain's images by hand, at the time of development
-for instance, it is possible by going into desired directory and using poky to build:
-
-- For building Domain-0:
-cd workspace_base/build/build/tmp/work/x86_64-xt-linux/dom0-image-thin-initramfs/1.0-r0/repo/
-
-- For building DomD:
-cd workspace_base/build/build/tmp/work/x86_64-xt-linux/domd-image-weston/1.0-r0/repo/
-
-- For building DomA:
-cd workspace_base/build/build/tmp/work/x86_64-xt-linux/domu-image-android/1.0-r0/repo/
-
-- For building DomU:
-cd workspace_base/build/build/tmp/work/x86_64-xt-linux/domu-image-weston/1.0-r0/repo/
-
-source poky/oe-init-build-env
-
-- For building Domain-0:
-bitbake core-image-thin-initramfs
-
-- For building DomD or DomU:
-bitbake core-image-weston
-
-- For building DomA:
-bitbake android
 
 Usage:
 ======
-It is possible to run system either using TFTP boot with NFS root or keeping
-all images on a storage device such as eMMC or SD card.
+It is possible to run system on a storage device such as eMMC or SD card.
 
 Different helpers scripts and docs are located at:
-build-workspace/build/meta-xt-prod-devel/doc
+build-workspace/build/meta-xt-cockpit-demo/doc
 
 Let's consider available boot options in details.
 
@@ -336,7 +235,7 @@ Let's consider available boot options in details.
 In order to boot system using a storage device, required storage device should be prepared
 and flashed beforehand. The mk_sdcard_image.sh script is intended to help with that:
 
-sudo ./mk_sdcard_image.sh -p /IMAGE_FOLDER -d /IMAGE_FILE -c devel
+sudo ./mk_sdcard_image.sh -p IMAGE_FOLDER -d IMAGE_FILE -c devel
 
 Where, IMAGE_FOLDER is a path to a folder where artifacts live (in the context of this document
 it is a "deploy" directory) and IMAGE_FILE is an output image file or physical device how
@@ -346,7 +245,7 @@ we need to specify '-c devel' for this product.
 1.1 In case of SDx card booting we just have to insert SD card to a Host machine and run a script,
 the latter will do all required actions automatically. All what we need to care about is to write
 proper environment variables from U-Boot command line (boot_dev/bootcmd) according to the chosen SDx.
-See workspace_base/meta-xt-prod-gen3-test/doc/u-boot-env-salvator-x.txt for details.
+See workspace_base/meta-xt-prod-cockpit-demo/doc/u-boot-env.txt for details.
 
 1.2 In case of eMMC booting, we have to have an access to it in order to flash images.
 It is going to be not quite easy as for removable SD card, but the one of the possible ways is
@@ -358,68 +257,15 @@ For example,
 
 prepare an image blob:
 
-- For system with DomA:
-sudo ./mk_sdcard_image.sh -p /IMAGE_FOLDER -d /home/emmc.img -c devel
-
-- For system with DomU:
-sudo ./mk_sdcard_image.sh -p /IMAGE_FOLDER -d /home/emmc.img -c gen3
+sudo ./mk_sdcard_image.sh -p IMAGE_FOLDER -d ./emmc.img -c devel
 
 and then run on target:
-dd if=/home/emmc.img of=/dev/mmcblk0
+dd if=/home/emmc.img of=/dev/mmcblk0 status=progress
 
 After getting eMMC flashed we have to choose it to be an boot device in a similar way as it is done
 for SD card.
 See u-boot-env.txt for details.
 
-2. Using TFTP boot with NFS root.
-In case of TFTP booting we have to copy the following boot images into target-accessible TFTP boot
-directory and extract guest domain rootfs images for being an NFS root directories for guest domains.
-See https://github.com/xen-troops/manifests/wiki on how to setup TFTP, NFS, etc.
-
-For example (for system with DomU),
-
-copy boot images to TFTP boot directory:
-sudo mkdir /srv
-cd workspace_base/build/build/tmp/deploy/dom0-image-thin-initramfs/images/generic-armv8-xt/
-sudo cp uInitramfs /srv/
-sudo cp Image /srv/
-cd workspace_base/build/build/tmp/deploy/domd-image-weston/images/MACHINE_NAME-xt/
-sudo cp dom0.dtb /srv/
-sudo cp xenpolicy /srv/
-sudo cp xen-uImage /srv/
-
-extract DomD rootfs images:
-sudo mkdir /srv/domd
-cd workspace_base/build/build/tmp/deploy/domd-image-weston/images/MACHINE_NAME-xt/
-sudo tar -xf core-image-weston-MACHINE_NAME-xt.tar.bz2 -C /srv/domd/
-
-extract DomU rootfs images:
-sudo mkdir /srv/domu
-cd workspace_base/build/build/tmp/deploy/domu-image-weston/images/MACHINE_NAME-xt/
-sudo tar -xf core-image-weston-MACHINE_NAME-xt.tar.bz2 -C /srv/domu/
-
-It worth mentioning that some changes to domain config files are necessary to switch between NFS
-and any of storage devices.
-
-There are two options for doing that. Either by modifying source files followed by rebuilding
-the whole Domain-0 or by modifying domain config files right in a built uInitramfs image which
-implies unpacking an image before and packing it back after (an "uirfs.sh" script which
-we will consider down the document is intended to help with that).
-
-In order to modify sources go to the files location in inner yocto:
-cd workspace_base/build/build/tmp/work/x86_64-xt-linux/dom0-image-thin-initramfs/1.0-r0/repo/meta-xt-prod-extra/recipes-extended/guest-addons/files
-
-- Edit domd-MACHINE_NAME.cfg to uncomment "extra" option which corresponds to NFS.
-- Edit domu-MACHINE_NAME.cfg to uncomment "extra" option which corresponds to NFS and comment "disk" option.
-
-and then rebuild Domain-0 manually:
-cd workspace_base/build/build/tmp/work/x86_64-xt-linux/dom0-image-thin-initramfs/1.0-r0/repo/
-source poky/oe-init-build-env
-bitbake core-image-thin-initramfs
-
-So, as you can see, varying U-Boot's "boot_dev" and "bootcmd" environment variables
-and domain config's "extra" and "disk" options it is possible to choose  different boot device
-for each system component. For example, boot system using TFTP and then use SD card for guest domains.
 
 Additional script available in the product.
 1. uirfs.sh.
@@ -441,17 +287,17 @@ For example, domain config files located at:
 pack it back:
 sudo ./uirfs.sh pack uInitramfs initramfs
 
-2. Product image structure (for system with DomA)
-The product image contains the following partitions: dom0, domd, domu/doma.
+2. Product image structure
+The product image contains the following partitions: dom0, domd, doma.
 DomA itself contains its partitions: system, vendor, misc, vbmeta, metadata, userdata.
 
 You can inspect partitions using losetup and lsblk.
-See example below for Ubuntu 18, assuming that the image was named 'prod-devel.img'.
+See example below for Ubuntu 18, assuming that the image was named 'image.img'.
 Pay attention that text after ## is a comment to console output.
 Sizes of partitions may vary.
 
 ```
-$ sudo losetup --find --partscan --show ./prod-devel.img
+$ sudo losetup --find --partscan --show ./image.img
 /dev/loop23
 
 $ lsblk /dev/loop23


### PR DESCRIPTION
Remove info related to not supported stuff:
  - DomU;
  - AOS VIS prebuilt binaries;
  - all machines except h3ulcb-4x2g-kf and salvator-xs-h3-4x2g;
  - multimedia prebuilt binaries;
  - steps to build separate domains;
  - TFTP/NFS boot os image.

Rework relevant info (aos-vis plugin, machine names, etc)

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>