### PR TITLE
aos-vis: Do not assign 10.0.0.1 to wwwivi

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-demo-hmi/cluster-dashboard-vis/cluster-dashboard-vis_git.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-demo-hmi/cluster-dashboard-vis/cluster-dashboard-vis_git.bb
@@ -21,11 +21,3 @@ RDEPENDS_${PN} += " \
 	qtwebsockets \
 	qtwebsockets-qmlplugins \
 "
-
-VISSERVER = "10.0.0.1    wwwivi"
-
-pkg_postinst_ontarget_${PN} () {
-    if ! grep -q '${VISSERVER}' $D${sysconfdir}/hosts ; then
-        echo '${VISSERVER}' >> $D${sysconfdir}/hosts
-    fi
-}


### PR DESCRIPTION
IP for wwwivi is provided in netbase_%.bbappend.

Also It could be better to use some kind of switch
to configure IP of VIS server.

This demo is intended to be used with VIS server in DomD.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>